### PR TITLE
First round of tests

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,19 @@
+{
+  "node": true,
+  "es5": true,
+  "esnext": true,
+  "bitwise": false,
+  "curly": false,
+  "eqeqeq": true,
+  "eqnull": true,
+  "immed": true,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "undef": true,
+  "strict": false,
+  "trailing": true,
+  "smarttabs": true,
+  "indent": 2,
+  "white": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - 0.8
+  - '0.8'
+  - '0.10'

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,57 @@
+/*global describe, beforeEach, it*/
+'use strict';
+
+var path    = require('path');
+var helpers = require('yeoman-generator').test;
+var assert  = require('assert');
+
+
+describe('Bootstrap generator test', function () {
+  beforeEach(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
+      if (err) {
+        return done(err);
+      }
+
+      this.webapp = helpers.createGenerator('bootstrap:app', [
+        '../../app'
+      ]);
+      done();
+    }.bind(this));
+  });
+
+  it('the generator can be required without throwing', function () {
+    // not testing the actual run of generators yet
+    this.app = require('../app');
+  });
+
+  it('creates expected files in compass mode', function (done) {
+    var expected = [
+      'app/styles/main.scss'
+    ];
+
+    helpers.mockPrompt(this.webapp, {
+      'compassBootstrap': 'Y'
+    });
+
+    this.webapp.run({}, function () {
+      helpers.assertFiles(expected);
+      done();
+    });
+  });
+
+  it('creates expected files in vanilla mode', function (done) {
+    var expected = [
+      'app/styles/bootstrap.css'
+    ];
+
+    helpers.mockPrompt(this.webapp, {
+      'compassBootstrap': 'N'
+    });
+
+    this.webapp.run({}, function () {
+      helpers.assertFiles(expected);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
See #3

One fails, but rightfully so because the referenced `bootstrap.css` does not exist. The tests do not cover the remote call to `compass-twitter-bootstrap` yet.
