### PR TITLE
Update packages.sass

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -43,7 +43,7 @@ Generator.prototype.bootstrapFiles = function bootstrapFiles() {
   // map format -> package name
   var packages = {
     css: 'bootstrap.css',
-    sass: 'bootstrap-sass',
+    sass: 'twbs-bootstrap-sass',
     less: 'components-bootstrap',
     stylus: 'bootstrap-stylus'
   };


### PR DESCRIPTION
According to the [official doc](https://github.com/twbs/bootstrap-sass), "`bootstrap-sass` is taken" and `bower search bootstrap-sass` returns a non-official version. This can be fixed by prefixing `twbs`, which is in the `keywords` section for the official version's [bower.json](https://github.com/twbs/bootstrap-sass/blob/master/bower.json).

![image](https://f.cloud.github.com/assets/992008/2242290/b0d06ce2-9cfd-11e3-8e63-3a206ec469ed.png)
