### PR TITLE
update Bootstrap Sass source and relevent tests

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -43,7 +43,7 @@ Generator.prototype.bootstrapFiles = function bootstrapFiles() {
   // map format -> package name
   var packages = {
     css: 'bootstrap.css',
-    sass: 'git://github.com/twbs/bootstrap-sass.git#v3.1.0',
+    sass: 'bootstrap-sass-official',
     less: 'components-bootstrap',
     stylus: 'bootstrap-stylus'
   };

--- a/test/test.js
+++ b/test/test.js
@@ -49,7 +49,7 @@ describe('Bootstrap generator test', function () {
     });
 
     this.app.run({}, function () {
-      assert.equal(this.bowerInstallCalls[0][0], 'git://github.com/twbs/bootstrap-sass.git#v3.1.0');
+      assert.equal(this.bowerInstallCalls[0][0], 'bootstrap-sass-official');
       done();
     }.bind(this));
   });


### PR DESCRIPTION
Hi,

Updated the bower source for Bootstrap Sass to `bootstrap-sass-official` so it returns the latest build from Bootstrap. Also updated the test suite. Cheers

![screen shot 2014-08-10 at 09 19 54](https://cloud.githubusercontent.com/assets/2131246/3868816/88be2b0c-2067-11e4-9ed2-9c2c1ea1c14e.png)
