### PR TITLE
Update Bootstrap CSS source and relevant tests. Closes #36

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -42,7 +42,7 @@ Generator.prototype.askFor = function askFor(argument) {
 Generator.prototype.bootstrapFiles = function bootstrapFiles() {
   // map format -> package name
   var packages = {
-    css: 'bootstrap.css',
+    css: 'bootstrap',
     sass: 'bootstrap-sass-official',
     less: 'components-bootstrap',
     stylus: 'bootstrap-stylus'

--- a/test/test.js
+++ b/test/test.js
@@ -32,13 +32,13 @@ describe('Bootstrap generator test', function () {
     this.app = require('../app');
   });
 
-  it('installs bootstrap.css', function (done) {
+  it('installs bootstrap', function (done) {
     helpers.mockPrompt(this.app, {
       format: 'css'
     });
 
     this.app.run({}, function () {
-      assert.equal(this.bowerInstallCalls[0][0], 'bootstrap.css');
+      assert.equal(this.bowerInstallCalls[0][0], 'bootstrap');
       done();
     }.bind(this));
   });
@@ -54,7 +54,7 @@ describe('Bootstrap generator test', function () {
     }.bind(this));
   });
 
-  it('installs bootstrap', function (done) {
+  it('installs components-bootstrap', function (done) {
     helpers.mockPrompt(this.app, {
       format: 'less'
     });


### PR DESCRIPTION
This PR request removes reference to old Bootstrap Bower package resulting in version 2.3.\* being used for `css` option. It also reword test for `less` option to use `components-bootstrap` as name of package being tested - which cleans wording of tests for each CSS version supported (css/sass/less/stylus). Now the name of options, tests and packages are consistent with Bower names.

```
- use official Bootstrap Bower package
- update installation test for Bootstrap css version
- update wording of Bootstrap less component test
```

test:

``` bash
Bootstrap generator test
    ✓ the generator can be required without throwing 
    ✓ installs bootstrap 
    ✓ installs sass-bootstrap 
    ✓ installs components-bootstrap 
    ✓ installs bootstrap-stylus 


  5 passing (35ms)
```

After this change using `css` option with generator:

``` bash
yo bootstrap
? In what format would you like the Bootstrap stylesheets? css
bower cached        git://github.com/twbs/bootstrap.git#3.3.1
bower validate      3.3.1 against git://github.com/twbs/bootstrap.git#*
bower cached        git://github.com/jquery/jquery.git#2.1.1
bower validate      2.1.1 against git://github.com/jquery/jquery.git#>= 1.9.1
bower install       bootstrap#3.3.1
bower install       jquery#2.1.1
bower no-json       No bower.json file to save to, use bower init to create one

bootstrap#3.3.1 bower_components/bootstrap
└── jquery#2.1.1

jquery#2.1.1 bower_components/jquery  
```
